### PR TITLE
docs: deprecate CodeCommit module

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 > [!IMPORTANT]
 > **This module is deprecated and will be archived.**
 >
-> AWS CodeCommit is no longer available to new AWS customers. Existing AWS CodeCommit customers can continue to use the service as normal, so this repository remains available as a reference for existing users.
+> AWS CodeCommit is no longer available to new AWS customers. Existing AWS CodeCommit customers can continue to use the service as normal, so this repository remains available as a reference for existing users. See the [AWS CodeCommit availability notice](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-codecommit-repository.html) and AWS's [migration guidance for moving CodeCommit repositories to another Git provider](https://aws.amazon.com/blogs/devops/how-to-migrate-your-aws-codecommit-repository-to-another-git-provider/).
 >
 > New projects should use another Git provider such as GitHub, GitLab, Bitbucket, or AWS-supported third-party integrations instead of starting new CodeCommit-based infrastructure.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 ![Terraform](https://lgallardo.com/images/terraform.jpg)
 # terraform-aws-codecommit
+
+> [!IMPORTANT]
+> **This module is deprecated and will be archived.**
+>
+> AWS CodeCommit is no longer available to new AWS customers. Existing AWS CodeCommit customers can continue to use the service as normal, so this repository remains available as a reference for existing users.
+>
+> New projects should use another Git provider such as GitHub, GitLab, Bitbucket, or AWS-supported third-party integrations instead of starting new CodeCommit-based infrastructure.
+
 Terraform module to create [AWS CodeCommit](https://aws.amazon.com/codecommit/) repositories. AWS CodeCommit is a fully-managed source control service that hosts secure Git-based repositories.
 
 ## Usage


### PR DESCRIPTION
## Summary
- Adds a prominent README notice that the module is deprecated and will be archived.
- Explains that AWS CodeCommit is no longer available to new AWS customers.
- Keeps the repository useful as a reference for existing CodeCommit users.

## Context
GitHub traffic still shows light usage, so the README should make the status clear before archiving the repository.

## Test Plan
- `git diff --check`
